### PR TITLE
File workspace piece table

### DIFF
--- a/deneb-core/src/engine/mod.rs
+++ b/deneb-core/src/engine/mod.rs
@@ -236,7 +236,7 @@ impl<C, S> Engine<C, S> {
                 let reply = self.file_workspaces
                     .get(&index)
                     .ok_or_else(|| EngineError::FileRead(index).into())
-                    .and_then(|ws| ws.read(offset, size as usize))
+                    .and_then(|ws| ws.read_at(offset, size as usize))
                     .map_err(|e| e.context(EngineError::FileRead(index)).into());
                 let _ = chan.send(Reply::ReadData(reply));
             }

--- a/deneb-core/src/file_workspace/mod.rs
+++ b/deneb-core/src/file_workspace/mod.rs
@@ -97,6 +97,12 @@ where
              &self.piece_table[last_piece_idx..]].join(&new_piece)
         };
 
+        // If the current write extended the file, this should be reflected in the file
+        // attributes
+        if (offset + buf_size) as u64 > self.attributes.size {
+            self.attributes.size = (offset + buf_size) as u64
+        }
+
         Ok(())
     }
 

--- a/deneb-core/src/file_workspace/mod.rs
+++ b/deneb-core/src/file_workspace/mod.rs
@@ -51,6 +51,8 @@ where
                 }
             })
             .collect::<Vec<_>>();
+        trace!("New workspace for inode {} - size: {}, num_chunks: {}",
+               inode.attributes.ino, inode.attributes.size, lower.chunks.len());
         FileWorkspace {
             attributes: inode.attributes,
             lower,
@@ -277,6 +279,7 @@ where
         if self.data.is_some() {
             self.data = None;
         }
+        trace!("Unloaded chunk {}", self.digest);
     }
 
     /// Return the content of the chunk in a slice
@@ -288,6 +291,8 @@ where
         if self.data.is_none() {
             self.data = Some(self.store.borrow().get_chunk(&self.digest)?);
         }
+        trace!("Loaded contents of chunk {} -  size: {}",
+               self.digest, self.size);
         // Note: The following unwrap should never panic
         Ok(self.data.as_ref().unwrap().as_slice())
     }

--- a/deneb-core/src/file_workspace/mod.rs
+++ b/deneb-core/src/file_workspace/mod.rs
@@ -60,7 +60,7 @@ where
     }
 
     /// Read `size` number of bytes, located at `offset`
-    pub(crate) fn read(&self, offset: usize, size: usize) -> DenebResult<Vec<u8>> {
+    pub(crate) fn read_at(&self, offset: usize, size: usize) -> DenebResult<Vec<u8>> {
         let slices = lookup_pieces(offset, size, &self.piece_table);
         let buffer = self.fill_buffer(&slices)?;
         Ok(buffer)
@@ -96,7 +96,6 @@ where
     }
 }
 
-
 /// Target of the piece, either the lower or the upper layer of the workspace
 enum PieceTarget {
     /// The index represents which chunk of the lower layer this piece is related to
@@ -127,7 +126,6 @@ struct PieceSlice {
     /// End position of the slice relative to the beginning of the piece
     end: usize,
 }
-
 
 /// The lower, immutable, layer of a `FileWorkspace` object
 ///
@@ -219,7 +217,6 @@ where
     }
 }
 
-
 /// Lookup a subset of pieces corresponding to a memory slice
 ///
 /// Given a piece table and a segment identified by `offset` - the
@@ -264,7 +261,6 @@ fn piece_idx_for_offset(offset: usize, piece_table: &[Piece]) -> (usize, usize) 
     (idx, offset_in_piece)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -288,7 +284,7 @@ mod tests {
             };
             let ws = FileWorkspace::new(&inode, Rc::clone(&store));
 
-            let res = ws.read(0, 17)?;
+            let res = ws.read_at(0, 17)?;
 
             assert_eq!(b"alabalaportocala", res.as_slice());
 

--- a/deneb-core/src/file_workspace/mod.rs
+++ b/deneb-core/src/file_workspace/mod.rs
@@ -347,14 +347,17 @@ mod tests {
             let mut ws = FileWorkspace::new(&inode, Rc::clone(&store));
 
             let res0 = ws.read_at(0, 17)?;
-
             assert_eq!(b"alabalaportocala", res0.as_slice());
 
             assert!(ws.write_at(2, b"written").is_ok());
 
             let res1 = ws.read_at(0, 17)?;
-
             assert_eq!(b"alwrittenrtocala", res1.as_slice());
+
+            assert!(ws.write_at(6, b"again").is_ok());
+
+            let res2 = ws.read_at(0, 17)?;
+            assert_eq!(b"alwritagainocala", res2.as_slice());
 
             ws.unload();
 


### PR DESCRIPTION
Implementing write support in the `FileWorkspace` object through a piece table approach.

The `FileWorkspace` object contains a lower layer composed of immutable chunks retrieved from the object store and an upper layer storing the changes made to the file with respect to the lower layer.

A piece table keeps track of the current composition of the file as a sequence of pieces - each piece identifies a segment (offset + size) of the lower or upper layers.