### PR TITLE
More trait objects

### DIFF
--- a/deneb-core/src/cas.rs
+++ b/deneb-core/src/cas.rs
@@ -15,7 +15,7 @@ pub fn hash(msg: &[u8]) -> Digest {
     Digest(sodium_hash(msg))
 }
 
-pub fn read_chunks<R: ::std::io::Read>(
+pub(crate) fn read_chunks<R: ::std::io::Read>(
     mut reader: R,
     buffer: &mut [u8],
 ) -> Result<Vec<(Digest, Vec<u8>)>, DenebError> {

--- a/deneb-core/src/catalog/lmdb.rs
+++ b/deneb-core/src/catalog/lmdb.rs
@@ -20,7 +20,7 @@ const CATALOG_VERSION: u32 = 1;
 
 // Note: Could be enhanced with an in-memory LRU cache
 /// A filesystem metadata catalog backed by an LMDB database
-pub struct LmdbCatalog {
+struct LmdbCatalog {
     env: Environment,
     inodes: Database,
     dir_entries: Database,

--- a/deneb-core/src/catalog/mem.rs
+++ b/deneb-core/src/catalog/mem.rs
@@ -6,27 +6,15 @@ use inode::INode;
 use super::*;
 use errors::CatalogError;
 
-pub struct MemCatalogBuilder;
-
-impl CatalogBuilder for MemCatalogBuilder {
-    fn create(&self, _path: &Path) -> DenebResult<Box<dyn Catalog>> {
-        Ok(Box::new(MemCatalog::new()))
-    }
-
-    fn open(&self, _path: &Path) -> DenebResult<Box<dyn Catalog>> {
-        Ok(Box::new(MemCatalog::new()))
-    }
-}
-
 #[derive(Default)]
-struct MemCatalog {
+pub(super) struct MemCatalog {
     inodes: HashMap<u64, INode>,
     dir_entries: HashMap<u64, HashMap<PathBuf, u64>>,
     max_index: u64,
 }
 
 impl MemCatalog {
-    fn new() -> MemCatalog {
+    pub(super) fn new() -> MemCatalog {
         Self::default()
     }
 }

--- a/deneb-core/src/catalog/mem.rs
+++ b/deneb-core/src/catalog/mem.rs
@@ -9,14 +9,12 @@ use errors::CatalogError;
 pub struct MemCatalogBuilder;
 
 impl CatalogBuilder for MemCatalogBuilder {
-    type Catalog = MemCatalog;
-
-    fn create<P: AsRef<Path>>(&self, _path: P) -> DenebResult<Self::Catalog> {
-        Ok(MemCatalog::new())
+    fn create(&self, _path: &Path) -> DenebResult<Box<dyn Catalog>> {
+        Ok(Box::new(MemCatalog::new()))
     }
 
-    fn open<P: AsRef<Path>>(&self, _path: P) -> DenebResult<Self::Catalog> {
-        Ok(MemCatalog::new())
+    fn open(&self, _path: &Path) -> DenebResult<Box<dyn Catalog>> {
+        Ok(Box::new(MemCatalog::new()))
     }
 }
 

--- a/deneb-core/src/catalog/mem.rs
+++ b/deneb-core/src/catalog/mem.rs
@@ -19,18 +19,20 @@ impl CatalogBuilder for MemCatalogBuilder {
 }
 
 #[derive(Default)]
-pub struct MemCatalog {
+struct MemCatalog {
     inodes: HashMap<u64, INode>,
     dir_entries: HashMap<u64, HashMap<PathBuf, u64>>,
     max_index: u64,
 }
 
 impl MemCatalog {
-    pub fn new() -> MemCatalog {
+    fn new() -> MemCatalog {
         Self::default()
     }
+}
 
-    pub fn show_stats(&self) {
+impl Catalog for MemCatalog {
+    fn show_stats(&self) {
         info!("Catalog stats: number of inodes: {}", self.inodes.len());
         info!("Directory entries:");
         for (k1, v1) in &self.dir_entries {
@@ -39,9 +41,7 @@ impl MemCatalog {
             }
         }
     }
-}
 
-impl Catalog for MemCatalog {
     fn get_max_index(&self) -> u64 {
         self.max_index
     }

--- a/deneb-core/src/catalog/mod.rs
+++ b/deneb-core/src/catalog/mod.rs
@@ -4,10 +4,10 @@ use errors::{DenebError, DenebResult};
 use inode::INode;
 
 mod mem;
-pub use self::mem::{MemCatalog, MemCatalogBuilder};
+pub use self::mem::MemCatalogBuilder;
 
 mod lmdb;
-pub use self::lmdb::{LmdbCatalog, LmdbCatalogBuilder};
+pub use self::lmdb::LmdbCatalogBuilder;
 
 /// Describes the interface of catalog builders
 pub trait CatalogBuilder {
@@ -35,7 +35,7 @@ pub trait Catalog: Send {
 }
 
 #[derive(Copy, Clone)]
-pub struct IndexGenerator {
+pub(crate) struct IndexGenerator {
     current_index: u64,
 }
 

--- a/deneb-core/src/catalog/mod.rs
+++ b/deneb-core/src/catalog/mod.rs
@@ -11,16 +11,14 @@ pub use self::lmdb::{LmdbCatalog, LmdbCatalogBuilder};
 
 /// Describes the interface of catalog builders
 pub trait CatalogBuilder {
-    type Catalog: self::Catalog;
+    fn create(&self, path: &Path) -> DenebResult<Box<dyn Catalog>>;
 
-    fn create<P: AsRef<Path>>(&self, path: P) -> DenebResult<Self::Catalog>;
-
-    fn open<P: AsRef<Path>>(&self, path: P) -> DenebResult<Self::Catalog>;
+    fn open(&self, path: &Path) -> DenebResult<Box<dyn Catalog>>;
 }
 
 /// Describes the interface of metadata catalogs
 ///
-pub trait Catalog {
+pub trait Catalog: Send {
     fn show_stats(&self) {}
 
     fn get_max_index(&self) -> u64;

--- a/deneb-core/src/engine/handle.rs
+++ b/deneb-core/src/engine/handle.rs
@@ -1,9 +1,7 @@
 use std::{ffi::OsStr, path::PathBuf};
 
-use catalog::Catalog;
 use errors::DenebResult;
 use inode::{FileAttributeChanges, FileAttributes, FileType};
-use store::Store;
 
 use super::{
     protocol::{make_request, RequestChannel},
@@ -15,18 +13,12 @@ use super::{
 };
 
 #[derive(Clone)]
-pub struct Handle<C, S>
-where
-    C: Catalog,
-    S: Store,
+pub struct Handle
 {
-    channel: RequestChannel<Engine<C, S>>,
+    channel: RequestChannel<Engine>,
 }
 
-impl<C, S> Handle<C, S>
-where
-    C: Catalog + 'static,
-    S: Store + 'static,
+impl Handle
 {
     // Client API
     pub fn get_attr(&self, _id: &RequestId, index: u64) -> DenebResult<FileAttributes> {
@@ -207,7 +199,7 @@ where
     }
 
     // Private functions
-    pub(in engine) fn new(channel: RequestChannel<Engine<C, S>>) -> Handle<C, S> {
+    pub(in engine) fn new(channel: RequestChannel<Engine>) -> Handle {
         Handle { channel }
     }
 }

--- a/deneb-core/src/engine/handle.rs
+++ b/deneb-core/src/engine/handle.rs
@@ -13,13 +13,11 @@ use super::{
 };
 
 #[derive(Clone)]
-pub struct Handle
-{
+pub struct Handle {
     channel: RequestChannel<Engine>,
 }
 
-impl Handle
-{
+impl Handle {
     // Client API
     pub fn get_attr(&self, _id: &RequestId, index: u64) -> DenebResult<FileAttributes> {
         make_request(GetAttr { index }, &self.channel)

--- a/deneb-core/src/engine/mod.rs
+++ b/deneb-core/src/engine/mod.rs
@@ -36,8 +36,7 @@ pub fn start_engine_prebuilt(
     catalog: Box<dyn Catalog>,
     store: Box<dyn Store>,
     queue_size: usize,
-) -> DenebResult<Handle>
-{
+) -> DenebResult<Handle> {
     let (tx, rx) = sync_channel(queue_size);
     let index_generator = IndexGenerator::starting_at(catalog.get_max_index())?;
     let engine_handle = Handle::new(tx);
@@ -66,8 +65,7 @@ pub fn start_engine(
     sync_dir: Option<PathBuf>,
     chunk_size: usize,
     queue_size: usize,
-) -> DenebResult<Handle>
-{
+) -> DenebResult<Handle> {
     let (catalog, store) = init(
         catalog_builder,
         store_builder,
@@ -85,8 +83,7 @@ fn init(
     work_dir: &Path,
     sync_dir: Option<PathBuf>,
     chunk_size: usize,
-) -> DenebResult<(Box<dyn Catalog>, Box<dyn Store>)>
-{
+) -> DenebResult<(Box<dyn Catalog>, Box<dyn Store>)> {
     // Create an object store
     let mut store = store_builder.at_dir(work_dir, chunk_size)?;
 
@@ -159,8 +156,7 @@ pub(in engine) struct Engine {
     index_generator: IndexGenerator,
 }
 
-impl RequestHandler<GetAttr> for Engine
-{
+impl RequestHandler<GetAttr> for Engine {
     fn handle(&mut self, request: &GetAttr) -> DenebResult<<GetAttr as Request>::Reply> {
         self.get_attr(request.index)
             .context(EngineError::GetAttr(request.index))
@@ -168,8 +164,7 @@ impl RequestHandler<GetAttr> for Engine
     }
 }
 
-impl RequestHandler<SetAttr> for Engine
-{
+impl RequestHandler<SetAttr> for Engine {
     fn handle(&mut self, request: &SetAttr) -> DenebResult<<SetAttr as Request>::Reply> {
         self.set_attr(request.index, &request.changes)
             .context(EngineError::SetAttr(request.index))
@@ -177,8 +172,7 @@ impl RequestHandler<SetAttr> for Engine
     }
 }
 
-impl RequestHandler<Lookup> for Engine
-{
+impl RequestHandler<Lookup> for Engine {
     fn handle(&mut self, request: &Lookup) -> DenebResult<<Lookup as Request>::Reply> {
         self.lookup(request.parent, &request.name)
             .context(EngineError::Lookup(request.parent, request.name.clone()))
@@ -186,8 +180,7 @@ impl RequestHandler<Lookup> for Engine
     }
 }
 
-impl RequestHandler<OpenDir> for Engine
-{
+impl RequestHandler<OpenDir> for Engine {
     fn handle(&mut self, request: &OpenDir) -> DenebResult<<OpenDir as Request>::Reply> {
         self.open_dir(request.index)
             .context(EngineError::DirOpen(request.index))
@@ -195,8 +188,7 @@ impl RequestHandler<OpenDir> for Engine
     }
 }
 
-impl RequestHandler<ReleaseDir> for Engine
-{
+impl RequestHandler<ReleaseDir> for Engine {
     fn handle(&mut self, request: &ReleaseDir) -> DenebResult<<ReleaseDir as Request>::Reply> {
         self.release_dir(request.index)
             .context(EngineError::DirClose(request.index))
@@ -204,8 +196,7 @@ impl RequestHandler<ReleaseDir> for Engine
     }
 }
 
-impl RequestHandler<ReadDir> for Engine
-{
+impl RequestHandler<ReadDir> for Engine {
     fn handle(&mut self, request: &ReadDir) -> DenebResult<<ReadDir as Request>::Reply> {
         self.read_dir(request.index)
             .context(EngineError::DirRead(request.index))
@@ -213,8 +204,7 @@ impl RequestHandler<ReadDir> for Engine
     }
 }
 
-impl RequestHandler<OpenFile> for Engine
-{
+impl RequestHandler<OpenFile> for Engine {
     fn handle(&mut self, request: &OpenFile) -> DenebResult<<OpenFile as Request>::Reply> {
         self.open_file(request.index, request.flags)
             .context(EngineError::FileOpen(request.index))
@@ -222,8 +212,7 @@ impl RequestHandler<OpenFile> for Engine
     }
 }
 
-impl RequestHandler<ReadData> for Engine
-{
+impl RequestHandler<ReadData> for Engine {
     fn handle(&mut self, request: &ReadData) -> DenebResult<<ReadData as Request>::Reply> {
         self.read_data(request.index, request.offset, request.size)
             .context(EngineError::FileRead(request.index))
@@ -231,8 +220,7 @@ impl RequestHandler<ReadData> for Engine
     }
 }
 
-impl RequestHandler<WriteData> for Engine
-{
+impl RequestHandler<WriteData> for Engine {
     fn handle(&mut self, request: &WriteData) -> DenebResult<<WriteData as Request>::Reply> {
         self.write_data(request.index, request.offset, &request.data)
             .context(EngineError::FileWrite(request.index))
@@ -240,8 +228,7 @@ impl RequestHandler<WriteData> for Engine
     }
 }
 
-impl RequestHandler<ReleaseFile> for Engine
-{
+impl RequestHandler<ReleaseFile> for Engine {
     fn handle(&mut self, request: &ReleaseFile) -> DenebResult<<ReleaseFile as Request>::Reply> {
         self.release_file(request.index)
             .context(EngineError::FileClose(request.index))
@@ -249,8 +236,7 @@ impl RequestHandler<ReleaseFile> for Engine
     }
 }
 
-impl RequestHandler<CreateFile> for Engine
-{
+impl RequestHandler<CreateFile> for Engine {
     fn handle(&mut self, request: &CreateFile) -> DenebResult<<CreateFile as Request>::Reply> {
         self.create_file(request.parent, &request.name, request.mode, request.flags)
             .context(EngineError::FileCreate(
@@ -261,8 +247,7 @@ impl RequestHandler<CreateFile> for Engine
     }
 }
 
-impl RequestHandler<CreateDir> for Engine
-{
+impl RequestHandler<CreateDir> for Engine {
     fn handle(&mut self, request: &CreateDir) -> DenebResult<<CreateDir as Request>::Reply> {
         self.create_dir(request.parent, &request.name, request.mode)
             .context(EngineError::DirCreate(request.parent, request.name.clone()))
@@ -270,8 +255,7 @@ impl RequestHandler<CreateDir> for Engine
     }
 }
 
-impl RequestHandler<Unlink> for Engine
-{
+impl RequestHandler<Unlink> for Engine {
     fn handle(&mut self, request: &Unlink) -> DenebResult<<Unlink as Request>::Reply> {
         self.remove(request.parent, &request.name)
             .context(EngineError::Unlink(request.parent, request.name.clone()))
@@ -279,8 +263,7 @@ impl RequestHandler<Unlink> for Engine
     }
 }
 
-impl RequestHandler<RemoveDir> for Engine
-{
+impl RequestHandler<RemoveDir> for Engine {
     fn handle(&mut self, request: &RemoveDir) -> DenebResult<<RemoveDir as Request>::Reply> {
         self.remove(request.parent, &request.name)
             .context(EngineError::RemoveDir(request.parent, request.name.clone()))
@@ -288,8 +271,7 @@ impl RequestHandler<RemoveDir> for Engine
     }
 }
 
-impl RequestHandler<Rename> for Engine
-{
+impl RequestHandler<Rename> for Engine {
     fn handle(&mut self, request: &Rename) -> DenebResult<<Rename as Request>::Reply> {
         self.rename(
             request.parent,
@@ -306,8 +288,7 @@ impl RequestHandler<Rename> for Engine
     }
 }
 
-impl Engine
-{
+impl Engine {
     // Note: We perform inefficient double lookups since Catalog::get_inode returns a Result
     //       and can't be used inside Entry::or_insert_with
     #[cfg_attr(feature = "cargo-clippy", allow(map_entry))]

--- a/deneb-core/src/engine/mod.rs
+++ b/deneb-core/src/engine/mod.rs
@@ -98,8 +98,9 @@ fn init(
     // Create the file metadata catalog and populate it with the contents of "sync_dir"
     if let Some(sync_dir) = sync_dir {
         {
+            //use std::ops::DerefMut;
             let mut catalog = catalog_builder.create(catalog_path.as_path())?;
-            populate_with_dir(&mut catalog, &mut store, sync_dir.as_path(), chunk_size)?;
+            populate_with_dir(&mut *catalog, &mut *store, sync_dir.as_path(), chunk_size)?;
             info!(
                 "Catalog populated with contents of {:?}",
                 sync_dir.as_path()

--- a/deneb-core/src/file_workspace.rs
+++ b/deneb-core/src/file_workspace.rs
@@ -22,16 +22,17 @@ pub(crate) struct FileWorkspace {
     size: u64,
 }
 
-impl FileWorkspace
-{
+impl FileWorkspace {
     /// Create a new `FileWorkspace` for an `INode`
     ///
     /// Constructs a new workspace object for the file described by
     /// `inode`. The function takes a reference-counted pointer to a
     /// `Store` object which is used by the underlying `Chunks` making
     /// up the lower, immutable, layer
-    pub(crate) fn new(inode: &INode, store: &Rc<RefCell<Box<dyn Store>>>) -> DenebResult<FileWorkspace>
-    {
+    pub(crate) fn new(
+        inode: &INode,
+        store: &Rc<RefCell<Box<dyn Store>>>,
+    ) -> DenebResult<FileWorkspace> {
         let lower = Lower::new(inode.chunks.as_slice(), store)?;
         let piece_table = inode
             .chunks
@@ -249,10 +250,12 @@ struct Lower {
     chunks: HashMap<usize, Arc<dyn Chunk>>,
 }
 
-impl Lower
-{
+impl Lower {
     /// Construct the lower layer using a provided list of `ChunkDescriptor`
-    fn new(chunk_descriptors: &[ChunkDescriptor], store: &Rc<RefCell<Box<dyn Store>>>) -> DenebResult<Lower> {
+    fn new(
+        chunk_descriptors: &[ChunkDescriptor],
+        store: &Rc<RefCell<Box<dyn Store>>>,
+    ) -> DenebResult<Lower> {
         let digests = chunk_descriptors
             .iter()
             .map(|&ChunkDescriptor { digest, .. }| digest)

--- a/deneb-core/src/file_workspace.rs
+++ b/deneb-core/src/file_workspace.rs
@@ -268,6 +268,7 @@ impl Lower {
     }
 
     // Load a single chunk
+    #[cfg_attr(feature = "cargo-clippy", allow(map_entry))]
     fn load_chunk(&mut self, index: usize) -> DenebResult<()> {
         let digest = self.digests[index];
         if !self.chunks.contains_key(&index) {
@@ -340,7 +341,7 @@ mod tests {
 
         let mut names: Vec<&[u8]> = vec![b"ala", b"bala", b"portocala"];
         let mut chunks = vec![];
-        for n in names.iter_mut() {
+        for n in &mut names {
             chunks.push(store.put_file(n)?);
         }
         let mut attributes = FileAttributes::default();

--- a/deneb-core/src/file_workspace.rs
+++ b/deneb-core/src/file_workspace.rs
@@ -337,7 +337,7 @@ mod tests {
     use util::run;
 
     fn make_test_workspace() -> DenebResult<FileWorkspace> {
-        let mut store = Builder::build(StoreType::InMemory, "/", 10000)?;
+        let mut store = Builder::create(StoreType::InMemory, "/", 10000)?;
 
         let mut names: Vec<&[u8]> = vec![b"ala", b"bala", b"portocala"];
         let mut chunks = vec![];
@@ -368,7 +368,7 @@ mod tests {
     #[test]
     fn write_into_empty() {
         run(|| {
-            let store = Builder::build(StoreType::InMemory, "/", 10000)?;
+            let store = Builder::create(StoreType::InMemory, "/", 10000)?;
 
             let inode = INode {
                 attributes: FileAttributes::default(),

--- a/deneb-core/src/file_workspace.rs
+++ b/deneb-core/src/file_workspace.rs
@@ -330,16 +330,14 @@ fn piece_idx_for_offset(offset: usize, piece_table: &[Piece]) -> (usize, usize) 
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
     use super::*;
 
     use inode::FileAttributes;
-    use store::{StoreBuilder, MemStoreBuilder};
+    use store::{Builder, StoreType};
     use util::run;
 
     fn make_test_workspace() -> DenebResult<FileWorkspace> {
-        let mut store = MemStoreBuilder.at_dir(&Path::new("/"), 10000)?;
+        let mut store = Builder::build(StoreType::InMemory, "/", 10000)?;
 
         let mut names: Vec<&[u8]> = vec![b"ala", b"bala", b"portocala"];
         let mut chunks = vec![];
@@ -370,7 +368,7 @@ mod tests {
     #[test]
     fn write_into_empty() {
         run(|| {
-            let store = MemStoreBuilder.at_dir(&Path::new("/"), 10000)?;
+            let store = Builder::build(StoreType::InMemory, "/", 10000)?;
 
             let inode = INode {
                 attributes: FileAttributes::default(),

--- a/deneb-core/src/file_workspace.rs
+++ b/deneb-core/src/file_workspace.rs
@@ -330,14 +330,16 @@ fn piece_idx_for_offset(offset: usize, piece_table: &[Piece]) -> (usize, usize) 
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::*;
 
     use inode::FileAttributes;
-    use store::MemStore;
+    use store::{StoreBuilder, MemStoreBuilder};
     use util::run;
 
     fn make_test_workspace() -> DenebResult<FileWorkspace> {
-        let mut store = Box::new(MemStore::new(10000));
+        let mut store = MemStoreBuilder.at_dir(&Path::new("/"), 10000)?;
 
         let mut names: Vec<&[u8]> = vec![b"ala", b"bala", b"portocala"];
         let mut chunks = vec![];
@@ -368,7 +370,7 @@ mod tests {
     #[test]
     fn write_into_empty() {
         run(|| {
-            let store = Box::new(MemStore::new(10000));
+            let store = MemStoreBuilder.at_dir(&Path::new("/"), 10000)?;
 
             let inode = INode {
                 attributes: FileAttributes::default(),

--- a/deneb-core/src/file_workspace.rs
+++ b/deneb-core/src/file_workspace.rs
@@ -341,10 +341,10 @@ mod tests {
     fn make_test_workspace() -> DenebResult<FileWorkspace<MemStore>> {
         let mut store = MemStore::new(10000);
 
-        let names = ["ala", "bala", "portocala"];
+        let mut names: Vec<&[u8]> = vec![b"ala", b"bala", b"portocala"];
         let mut chunks = vec![];
-        for n in names.iter() {
-            chunks.push(store.put_file(n.as_bytes())?);
+        for n in names.iter_mut() {
+            chunks.push(store.put_file(n)?);
         }
         let mut attributes = FileAttributes::default();
         attributes.size = 16;

--- a/deneb-core/src/lib.rs
+++ b/deneb-core/src/lib.rs
@@ -60,15 +60,12 @@ pub fn init() -> DenebResult<()> {
     Ok(())
 }
 
-pub fn populate_with_dir<C, S>(
-    catalog: &mut C,
-    store: &mut S,
+pub fn populate_with_dir(
+    catalog: &mut Box<dyn Catalog>,
+    store: &mut Box<dyn Store>,
     dir: &Path,
     chunk_size: usize,
 ) -> DenebResult<()>
-where
-    C: Catalog,
-    S: Store,
 {
     let attrs = FileAttributes::with_stats(lstat(dir)?, 1);
     catalog.add_inode(INode::new(attrs, vec![]))?;
@@ -88,18 +85,15 @@ where
     Ok(())
 }
 
-fn visit_dirs<C, S>(
-    catalog: &mut C,
-    store: &mut S,
+fn visit_dirs(
+    catalog: &mut Box<dyn Catalog>,
+    store: &mut Box<dyn Store>,
     index_generator: &mut IndexGenerator,
     buffer: &mut [u8],
     dir: &Path,
     dir_index: u64,
     parent_index: u64,
 ) -> DenebResult<()>
-where
-    C: Catalog,
-    S: Store,
 {
     catalog.add_dir_entry(dir_index, Path::new("."), dir_index)?;
     catalog.add_dir_entry(dir_index, Path::new(".."), parent_index)?;

--- a/deneb-core/src/lib.rs
+++ b/deneb-core/src/lib.rs
@@ -61,8 +61,8 @@ pub fn init() -> DenebResult<()> {
 }
 
 pub fn populate_with_dir(
-    catalog: &mut Box<dyn Catalog>,
-    store: &mut Box<dyn Store>,
+    catalog: &mut dyn Catalog,
+    store: &mut dyn Store,
     dir: &Path,
     chunk_size: usize,
 ) -> DenebResult<()> {
@@ -85,8 +85,8 @@ pub fn populate_with_dir(
 }
 
 fn visit_dirs(
-    catalog: &mut Box<dyn Catalog>,
-    store: &mut Box<dyn Store>,
+    catalog: &mut dyn Catalog,
+    store: &mut dyn Store,
     index_generator: &mut IndexGenerator,
     buffer: &mut [u8],
     dir: &Path,

--- a/deneb-core/src/lib.rs
+++ b/deneb-core/src/lib.rs
@@ -65,8 +65,7 @@ pub fn populate_with_dir(
     store: &mut Box<dyn Store>,
     dir: &Path,
     chunk_size: usize,
-) -> DenebResult<()>
-{
+) -> DenebResult<()> {
     let attrs = FileAttributes::with_stats(lstat(dir)?, 1);
     catalog.add_inode(INode::new(attrs, vec![]))?;
 
@@ -93,8 +92,7 @@ fn visit_dirs(
     dir: &Path,
     dir_index: u64,
     parent_index: u64,
-) -> DenebResult<()>
-{
+) -> DenebResult<()> {
     catalog.add_dir_entry(dir_index, Path::new("."), dir_index)?;
     catalog.add_dir_entry(dir_index, Path::new(".."), parent_index)?;
 

--- a/deneb-core/src/store/disk.rs
+++ b/deneb-core/src/store/disk.rs
@@ -116,13 +116,14 @@ mod tests {
     #[test]
     fn diskstore_create_put_get() {
         run(|| {
+            const BYTES: &[u8] = b"alabalaportocala";
             let temp_dir = TempDir::new("/tmp/deneb_test_diskstore")?;
             let sb = DiskStoreBuilder;
             let mut store = sb.at_dir(temp_dir.path(), 10000)?;
-            let v1: Vec<u8> = vec![0 as u8; 1000];
-            let descriptors = store.put_file_chunked(v1.as_slice())?;
+            let mut v1: &[u8] = BYTES.clone();
+            let descriptors = store.put_file_chunked(&mut v1)?;
             let v2 = store.get_chunk(&descriptors[0].digest)?;
-            assert_eq!(v1.as_slice(), v2.get_slice());
+            assert_eq!(BYTES, v2.get_slice());
             Ok(())
         });
     }

--- a/deneb-core/src/store/disk.rs
+++ b/deneb-core/src/store/disk.rs
@@ -11,31 +11,12 @@ use cas::Digest;
 use errors::{DenebResult, StoreError};
 use util::atomic_write;
 
-use super::{Chunk, MmapChunk, Store, StoreBuilder};
+use super::{Chunk, MmapChunk, Store};
 
 const OBJECT_PATH: &str = "data";
 const PREFIX_SIZE: usize = 2;
 
 const CACHE_MAX_OBJECTS: usize = 100;
-
-pub struct DiskStoreBuilder;
-
-impl StoreBuilder for DiskStoreBuilder {
-    fn at_dir(&self, dir: &Path, chunk_size: usize) -> DenebResult<Box<dyn Store>> {
-        let root_dir = dir;
-        let object_dir = root_dir.join(OBJECT_PATH);
-
-        // Create object dir
-        create_dir_all(&object_dir)?;
-
-        Ok(Box::new(DiskStore {
-            chunk_size,
-            _root_dir: root_dir.to_owned(),
-            object_dir,
-            cache: RefCell::new(LruCache::new(CACHE_MAX_OBJECTS)),
-        }))
-    }
-}
 
 /// A disk-based implementation of the `Store` trait.
 ///
@@ -46,7 +27,7 @@ impl StoreBuilder for DiskStoreBuilder {
 /// For example:
 /// The full path at which a file with the digest "abcdefg123456" is stored is:
 /// "`root_dir`/data/ab/cdefg123456"
-pub struct DiskStore {
+pub(super) struct DiskStore {
     chunk_size: usize,
     _root_dir: PathBuf,
     object_dir: PathBuf,
@@ -54,6 +35,21 @@ pub struct DiskStore {
 }
 
 impl DiskStore {
+    pub(super) fn new(dir: &Path, chunk_size: usize) -> DenebResult<DiskStore> {
+        let root_dir = dir;
+        let object_dir = root_dir.join(OBJECT_PATH);
+
+        // Create object dir
+        create_dir_all(&object_dir)?;
+
+        Ok(DiskStore {
+            chunk_size,
+            _root_dir: root_dir.to_owned(),
+            object_dir,
+            cache: RefCell::new(LruCache::new(CACHE_MAX_OBJECTS)),
+        })
+    }
+
     /// Given a Digest, returns the absolute file path and the directory path
     /// corresponding to the object in the store
     fn digest_to_path(&self, digest: &Digest) -> (PathBuf, PathBuf) {
@@ -116,8 +112,7 @@ mod tests {
         run(|| {
             const BYTES: &[u8] = b"alabalaportocala";
             let temp_dir = TempDir::new("/tmp/deneb_test_diskstore")?;
-            let sb = DiskStoreBuilder;
-            let mut store = sb.at_dir(temp_dir.path(), 10000)?;
+            let mut store = DiskStore::new(temp_dir.path(), 10000)?;
             let mut v1: &[u8] = BYTES;
             let descriptors = store.put_file_chunked(&mut v1)?;
             let v2 = store.get_chunk(&descriptors[0].digest)?;

--- a/deneb-core/src/store/disk.rs
+++ b/deneb-core/src/store/disk.rs
@@ -118,7 +118,7 @@ mod tests {
             let temp_dir = TempDir::new("/tmp/deneb_test_diskstore")?;
             let sb = DiskStoreBuilder;
             let mut store = sb.at_dir(temp_dir.path(), 10000)?;
-            let mut v1: &[u8] = BYTES.clone();
+            let mut v1: &[u8] = BYTES;
             let descriptors = store.put_file_chunked(&mut v1)?;
             let v2 = store.get_chunk(&descriptors[0].digest)?;
             assert_eq!(BYTES, v2.get_slice());

--- a/deneb-core/src/store/mem.rs
+++ b/deneb-core/src/store/mem.rs
@@ -67,7 +67,7 @@ mod tests {
         run(|| {
             const BYTES: &[u8] = b"alabalaportocala";
             let mut store: MemStore = MemStore::new(10000);
-            let mut v1: &[u8] = BYTES.clone();
+            let mut v1: &[u8] = BYTES;
             let descriptors = store.put_file_chunked(&mut v1)?;
             let v2 = store.get_chunk(&descriptors[0].digest)?;
             assert_eq!(BYTES, v2.get_slice());

--- a/deneb-core/src/store/mem.rs
+++ b/deneb-core/src/store/mem.rs
@@ -1,28 +1,19 @@
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::Arc;
 
 use cas::Digest;
 use errors::{DenebResult, StoreError};
 
-use super::{Chunk, MemChunk, Store, StoreBuilder};
-
-pub struct MemStoreBuilder;
-
-impl StoreBuilder for MemStoreBuilder {
-    fn at_dir(&self, _dir: &Path, chunk_size: usize) -> DenebResult<Box<dyn Store>> {
-        Ok(Box::new(MemStore::new(chunk_size)))
-    }
-}
+use super::{Chunk, MemChunk, Store};
 
 #[derive(Default)]
-pub struct MemStore {
+pub(super) struct MemStore {
     chunk_size: usize,
     objects: HashMap<Digest, Arc<dyn Chunk>>,
 }
 
 impl MemStore {
-    pub fn new(chunk_size: usize) -> MemStore {
+    pub(super) fn new(chunk_size: usize) -> MemStore {
         MemStore {
             chunk_size,
             objects: HashMap::new(),

--- a/deneb-core/src/store/mem.rs
+++ b/deneb-core/src/store/mem.rs
@@ -67,11 +67,12 @@ mod tests {
     #[test]
     fn memstore_create_put_get() {
         run(|| {
+            const BYTES: &[u8] = b"alabalaportocala";
             let mut store: MemStore = MemStore::new(10000);
-            let v1: Vec<u8> = vec![1, 2, 3];
-            let descriptors = store.put_file_chunked(v1.as_slice())?;
+            let mut v1: &[u8] = BYTES.clone();
+            let descriptors = store.put_file_chunked(&mut v1)?;
             let v2 = store.get_chunk(&descriptors[0].digest)?;
-            assert_eq!(v1.as_slice(), v2.get_slice());
+            assert_eq!(BYTES, v2.get_slice());
             Ok(())
         })
     }

--- a/deneb-core/src/store/mem.rs
+++ b/deneb-core/src/store/mem.rs
@@ -28,10 +28,6 @@ impl MemStore {
             objects: HashMap::new(),
         }
     }
-
-    pub fn show_stats(&self) {
-        info!("MemStore: number of objects: {}", self.objects.len());
-    }
 }
 
 impl Store for MemStore {

--- a/deneb-core/src/store/mem.rs
+++ b/deneb-core/src/store/mem.rs
@@ -10,17 +10,15 @@ use super::{Chunk, MemChunk, Store, StoreBuilder};
 pub struct MemStoreBuilder;
 
 impl StoreBuilder for MemStoreBuilder {
-    type Store = MemStore;
-
-    fn at_dir<P: AsRef<Path>>(&self, _dir: P, chunk_size: usize) -> DenebResult<Self::Store> {
-        Ok(Self::Store::new(chunk_size))
+    fn at_dir(&self, _dir: &Path, chunk_size: usize) -> DenebResult<Box<dyn Store>> {
+        Ok(Box::new(MemStore::new(chunk_size)))
     }
 }
 
 #[derive(Default)]
 pub struct MemStore {
     chunk_size: usize,
-    objects: HashMap<Digest, Arc<Chunk>>,
+    objects: HashMap<Digest, Arc<dyn Chunk>>,
 }
 
 impl MemStore {

--- a/deneb-core/src/store/mod.rs
+++ b/deneb-core/src/store/mod.rs
@@ -44,7 +44,7 @@ pub trait Store {
 
     /// Write a file into the repository without chunking
     ///
-    fn put_file<R: Read>(&mut self, mut data: R) -> DenebResult<ChunkDescriptor> {
+    fn put_file(&mut self, data: &mut dyn Read) -> DenebResult<ChunkDescriptor> {
         let mut buf = vec![];
         let n = data.read_to_end(&mut buf)?;
         let digest = hash(buf.as_slice());
@@ -55,7 +55,7 @@ pub trait Store {
 
     /// Write a file into the repository with chunking
     ///
-    fn put_file_chunked<R: Read>(&mut self, data: R) -> DenebResult<Vec<ChunkDescriptor>> {
+    fn put_file_chunked(&mut self, data: &mut dyn Read) -> DenebResult<Vec<ChunkDescriptor>> {
         let mut descriptors = vec![];
         let mut buf = vec![0 as u8; self.chunk_size()];
         for (digest, obj) in read_chunks(data, buf.as_mut_slice())? {

--- a/deneb-core/src/store/mod.rs
+++ b/deneb-core/src/store/mod.rs
@@ -9,19 +9,28 @@ use inode::ChunkDescriptor;
 mod chunk;
 pub(crate) use self::chunk::{Chunk, MemChunk, MmapChunk};
 
-mod mem;
-pub use self::mem::MemStoreBuilder;
-
 mod disk;
-pub use self::disk::DiskStoreBuilder;
+mod mem;
 
-/// Builder types for `Store` objects
-pub trait StoreBuilder {
-    /// Construct the new store at the specified directory
-    ///
-    /// It is assumed that the newly constructed store will keep any
-    /// objects (chunks) already present at the specified directory
-    fn at_dir(&self, dir: &Path, chunk_size: usize) -> DenebResult<Box<dyn Store>>;
+#[derive(Clone, Copy)]
+pub enum StoreType {
+    InMemory,
+    OnDisk,
+}
+
+pub struct Builder;
+
+impl Builder {
+    pub fn build<P: AsRef<Path>>(
+        store_type: StoreType,
+        dir: P,
+        chunk_size: usize,
+    ) -> DenebResult<Box<dyn Store>> {
+        match store_type {
+            StoreType::InMemory => Ok(Box::new(mem::MemStore::new(chunk_size))),
+            StoreType::OnDisk => Ok(Box::new(disk::DiskStore::new(dir.as_ref(), chunk_size)?)),
+        }
+    }
 }
 
 /// Types which can perform IO into repository storage

--- a/deneb-core/src/store/mod.rs
+++ b/deneb-core/src/store/mod.rs
@@ -17,18 +17,16 @@ pub use self::disk::{DiskStore, DiskStoreBuilder};
 
 /// Builder types for `Store` objects
 pub trait StoreBuilder {
-    type Store: self::Store;
-
     /// Construct the new store at the specified directory
     ///
     /// It is assumed that the newly constructed store will keep any
     /// objects (chunks) already present at the specified directory
-    fn at_dir<P: AsRef<Path>>(&self, dir: P, chunk_size: usize) -> DenebResult<Self::Store>;
+    fn at_dir(&self, dir: &Path, chunk_size: usize) -> DenebResult<Box<dyn Store>>;
 }
 
 /// Types which can perform IO into repository storage
 ///
-pub trait Store {
+pub trait Store: Send {
     /// Returns the chunk size used by the store
     fn chunk_size(&self) -> usize;
 

--- a/deneb-core/src/store/mod.rs
+++ b/deneb-core/src/store/mod.rs
@@ -21,15 +21,15 @@ pub enum StoreType {
 pub struct Builder;
 
 impl Builder {
-    pub fn build<P: AsRef<Path>>(
+    pub fn create<P: AsRef<Path>>(
         store_type: StoreType,
         dir: P,
         chunk_size: usize,
     ) -> DenebResult<Box<dyn Store>> {
-        match store_type {
-            StoreType::InMemory => Ok(Box::new(mem::MemStore::new(chunk_size))),
-            StoreType::OnDisk => Ok(Box::new(disk::DiskStore::new(dir.as_ref(), chunk_size)?)),
-        }
+        Ok(match store_type {
+            StoreType::InMemory => Box::new(mem::MemStore::new(chunk_size)),
+            StoreType::OnDisk => Box::new(disk::DiskStore::new(dir.as_ref(), chunk_size)?),
+        })
     }
 }
 

--- a/deneb-core/src/store/mod.rs
+++ b/deneb-core/src/store/mod.rs
@@ -10,10 +10,10 @@ mod chunk;
 pub(crate) use self::chunk::{Chunk, MemChunk, MmapChunk};
 
 mod mem;
-pub use self::mem::{MemStore, MemStoreBuilder};
+pub use self::mem::MemStoreBuilder;
 
 mod disk;
-pub use self::disk::{DiskStore, DiskStoreBuilder};
+pub use self::disk::DiskStoreBuilder;
 
 /// Builder types for `Store` objects
 pub trait StoreBuilder {

--- a/deneb-core/src/util.rs
+++ b/deneb-core/src/util.rs
@@ -40,11 +40,11 @@ pub fn run<F: Fn() -> DenebResult<()>>(f: F) {
 }
 
 // Safe wrappers on top of  some libc functions
-pub fn get_egid() -> gid_t {
+pub(crate) fn get_egid() -> gid_t {
     unsafe { getegid() }
 }
 
-pub fn get_euid() -> uid_t {
+pub(crate) fn get_euid() -> uid_t {
     unsafe { geteuid() }
 }
 

--- a/deneb-fuse/src/fs.rs
+++ b/deneb-fuse/src/fs.rs
@@ -18,7 +18,7 @@ use std::{
 use deneb_core::{
     engine::{Handle, RequestId},
     errors::{print_error_with_causes, DenebResult, EngineError, UnixError},
-    inode::{FileAttributeChanges, FileAttributes, FileType as FT}
+    inode::{FileAttributeChanges, FileAttributes, FileType as FT},
 };
 
 pub struct Session<'a> {
@@ -53,13 +53,11 @@ impl<'a> Session<'a> {
     }
 }
 
-pub struct Fs
-{
+pub struct Fs {
     engine_handle: Handle,
 }
 
-impl<'a> Fs
-{
+impl<'a> Fs {
     pub fn mount<P: AsRef<Path>>(
         mount_point: &P,
         engine_handle: Handle,
@@ -74,8 +72,7 @@ impl<'a> Fs
     }
 }
 
-impl Filesystem for Fs
-{
+impl Filesystem for Fs {
     fn getattr(&mut self, req: &Request, ino: u64, reply: ReplyAttr) {
         match self.engine_handle.get_attr(&to_request_id(req), ino) {
             Ok(attrs) => {

--- a/deneb-fuse/src/fs.rs
+++ b/deneb-fuse/src/fs.rs
@@ -16,9 +16,9 @@ use std::{
 };
 
 use deneb_core::{
-    catalog::Catalog, engine::{Handle, RequestId},
+    engine::{Handle, RequestId},
     errors::{print_error_with_causes, DenebResult, EngineError, UnixError},
-    inode::{FileAttributeChanges, FileAttributes, FileType as FT}, store::Store,
+    inode::{FileAttributeChanges, FileAttributes, FileType as FT}
 };
 
 pub struct Session<'a> {
@@ -53,22 +53,16 @@ impl<'a> Session<'a> {
     }
 }
 
-pub struct Fs<C, S>
-where
-    C: Catalog,
-    S: Store,
+pub struct Fs
 {
-    engine_handle: Handle<C, S>,
+    engine_handle: Handle,
 }
 
-impl<'a, C, S> Fs<C, S>
-where
-    C: Catalog + 'static,
-    S: Store + 'static,
+impl<'a> Fs
 {
     pub fn mount<P: AsRef<Path>>(
         mount_point: &P,
-        engine_handle: Handle<C, S>,
+        engine_handle: Handle,
         options: &[&OsStr],
     ) -> DenebResult<Session<'a>> {
         let fs = Fs { engine_handle };
@@ -80,10 +74,7 @@ where
     }
 }
 
-impl<C, S> Filesystem for Fs<C, S>
-where
-    C: Catalog + 'static,
-    S: Store + 'static,
+impl Filesystem for Fs
 {
     fn getattr(&mut self, req: &Request, ino: u64, reply: ReplyAttr) {
         match self.engine_handle.get_attr(&to_request_id(req), ino) {

--- a/deneb-fuse/tests/fuse_inout.rs
+++ b/deneb-fuse/tests/fuse_inout.rs
@@ -23,7 +23,7 @@ use common::*;
 use deneb_core::{
     catalog::{CatalogBuilder, LmdbCatalogBuilder, MemCatalogBuilder},
     engine::{start_engine, start_engine_prebuilt}, errors::DenebResult, populate_with_dir,
-    store::{DiskStoreBuilder, MemStoreBuilder, StoreBuilder},
+    store::{Builder as StoreBuilder, StoreType},
 };
 use deneb_fuse::fs::{Fs, Session};
 
@@ -86,7 +86,7 @@ fn init_test<'a>(
     match test_type {
         TestType::InMemory => {
             // The paths given to the in-memory builders doesn't matter
-            let mut store = MemStoreBuilder.at_dir(&work_dir, chunk_size)?;
+            let mut store = StoreBuilder::build(StoreType::InMemory, &work_dir, chunk_size)?;
             let mut catalog = MemCatalogBuilder.create(&work_dir)?;
             populate_with_dir(&mut *catalog, &mut *store, input, chunk_size)?;
             let handle = start_engine_prebuilt(catalog, store, 1000)?;
@@ -95,7 +95,7 @@ fn init_test<'a>(
         TestType::OnDisk => {
             let handle = start_engine(
                 &LmdbCatalogBuilder,
-                &DiskStoreBuilder,
+                StoreType::OnDisk,
                 &work_dir,
                 Some(input.to_owned()),
                 chunk_size,

--- a/deneb-fuse/tests/fuse_inout.rs
+++ b/deneb-fuse/tests/fuse_inout.rs
@@ -88,7 +88,7 @@ fn init_test<'a>(
             // The paths given to the in-memory builders doesn't matter
             let mut store = MemStoreBuilder.at_dir(&work_dir, chunk_size)?;
             let mut catalog = MemCatalogBuilder.create(&work_dir)?;
-            populate_with_dir(&mut catalog, &mut store, input, chunk_size)?;
+            populate_with_dir(&mut *catalog, &mut *store, input, chunk_size)?;
             let handle = start_engine_prebuilt(catalog, store, 1000)?;
             Fs::mount(&mount_point, handle, &options)
         }

--- a/deneb-fuse/tests/fuse_inout.rs
+++ b/deneb-fuse/tests/fuse_inout.rs
@@ -21,7 +21,7 @@ mod common;
 use common::*;
 
 use deneb_core::{
-    catalog::{CatalogBuilder, LmdbCatalogBuilder, MemCatalogBuilder},
+    catalog::{Builder as CatalogBuilder, CatalogType},
     engine::{start_engine, start_engine_prebuilt}, errors::DenebResult, populate_with_dir,
     store::{Builder as StoreBuilder, StoreType},
 };
@@ -86,15 +86,15 @@ fn init_test<'a>(
     match test_type {
         TestType::InMemory => {
             // The paths given to the in-memory builders doesn't matter
-            let mut store = StoreBuilder::build(StoreType::InMemory, &work_dir, chunk_size)?;
-            let mut catalog = MemCatalogBuilder.create(&work_dir)?;
+            let mut store = StoreBuilder::create(StoreType::InMemory, &work_dir, chunk_size)?;
+            let mut catalog = CatalogBuilder::create(CatalogType::InMemory, &work_dir)?;
             populate_with_dir(&mut *catalog, &mut *store, input, chunk_size)?;
             let handle = start_engine_prebuilt(catalog, store, 1000)?;
             Fs::mount(&mount_point, handle, &options)
         }
         TestType::OnDisk => {
             let handle = start_engine(
-                &LmdbCatalogBuilder,
+                CatalogType::Lmdb,
                 StoreType::OnDisk,
                 &work_dir,
                 Some(input.to_owned()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use failure::ResultExt;
 use std::ffi::OsStr;
 
 use deneb_core::{
-    catalog::LmdbCatalogBuilder, engine::start_engine, errors::DenebResult, store::StoreType,
+    catalog::CatalogType, engine::start_engine, errors::DenebResult, store::StoreType,
 };
 use deneb_fuse::fs::Fs;
 
@@ -40,9 +40,8 @@ fn main() -> DenebResult<()> {
     info!("Force unmount: {}", params.force_unmount);
 
     // Create the file system data structure
-    let cb = LmdbCatalogBuilder;
     let handle = start_engine(
-        &cb,
+        CatalogType::Lmdb,
         StoreType::OnDisk,
         &params.work_dir,
         params.sync_dir,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use failure::ResultExt;
 use std::ffi::OsStr;
 
 use deneb_core::{
-    catalog::LmdbCatalogBuilder, engine::start_engine, errors::DenebResult, store::DiskStoreBuilder,
+    catalog::LmdbCatalogBuilder, engine::start_engine, errors::DenebResult, store::StoreType,
 };
 use deneb_fuse::fs::Fs;
 
@@ -41,10 +41,9 @@ fn main() -> DenebResult<()> {
 
     // Create the file system data structure
     let cb = LmdbCatalogBuilder;
-    let sb = DiskStoreBuilder;
     let handle = start_engine(
         &cb,
-        &sb,
+        StoreType::OnDisk,
         &params.work_dir,
         params.sync_dir,
         params.chunk_size,


### PR DESCRIPTION
The `Store` and `Catalog` traits, and their corresponding builder traits, are now used as trait objects. This simplifies the code and avoids the proliferation of these traits as type parameters inside the `deneb-core` trait and into the frontend (the `deneb-fuse` crate).

