### PR TITLE
Update Engine client interface

### DIFF
--- a/deneb-core/src/engine/mod.rs
+++ b/deneb-core/src/engine/mod.rs
@@ -25,7 +25,7 @@ use self::{
     protocol::{HandlerProxy, Request, RequestHandler},
     requests::{
         CreateDir, CreateFile, GetAttr, Lookup, OpenDir, OpenFile, ReadData, ReadDir, ReleaseDir,
-        ReleaseFile, RemoveDir, Rename, SetAttr, Unlink, WriteData,
+        ReleaseFile, RemoveDir, Rename, SetAttr, Unlink, WriteData, Ping,
     },
 };
 
@@ -53,6 +53,8 @@ pub fn start_engine_prebuilt(
         }
         info!("Engine event loop finished.");
     });
+
+    engine_handle.ping();
 
     Ok(engine_handle)
 }
@@ -280,6 +282,13 @@ impl RequestHandler<Rename> for Engine {
                 request.new_name.clone(),
             ))
             .map_err(Error::from)
+    }
+}
+
+impl RequestHandler<Ping> for Engine {
+    fn handle(&mut self, _request: &Ping) -> DenebResult<()> {
+        debug!("Engine received ping request.");
+        Ok(())
     }
 }
 

--- a/deneb-core/src/engine/requests.rs
+++ b/deneb-core/src/engine/requests.rs
@@ -160,3 +160,9 @@ pub(in engine) struct Rename {
 impl Request for Rename {
     type Reply = ();
 }
+
+pub(in engine) struct Ping;
+
+impl Request for Ping {
+    type Reply = ();
+}


### PR DESCRIPTION
The Engine now offers the call and cast methods. Call is used for
blocking requests where a reply is expected, while cast is used for
"fire-and-forget" requests without any reply data.